### PR TITLE
Updates for Spring 2024 semester

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
 	"name": "NYU DevOps",
-	"image": "rofrano/nyu-devops-base:fa23",
+	"image": "rofrano/nyu-devops-base:sp24",
 	"customizations": {
 		"vscode": {
 			"extensions": [

--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -1,0 +1,46 @@
+name: Docker Publish
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+env:
+  REGISTRY: docker.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  # Build and push a multi-platform Docker image to Docker Hub
+  publish-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Docker Setup QEMU
+        uses: docker/setup-qemu-action@v2
+        
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}          
+
+      - name: Build and push ${{ github.ref_name }}
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest

--- a/.github/workflows/publish-quay.yaml
+++ b/.github/workflows/publish-quay.yaml
@@ -1,0 +1,46 @@
+name: Quay Publish
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+env:
+  REGISTRY: quay.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  # Build and push a multi-platform Docker image to Docker Hub
+  publish-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Docker Setup QEMU
+        uses: docker/setup-qemu-action@v2
+        
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.QUAYIO_USERNAME }}
+          password: ${{ secrets.QUAYIO_TOKEN }}          
+
+      - name: Build and push ${{ github.ref_name }}
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ FROM python:3.11-slim
 # Add any tools that are needed beyond Python 3.11
 RUN apt-get update && \
     apt-get install -y sudo vim make git zip tree curl wget jq procps net-tools && \
-    apt-get install -y gcc libpq-dev && \
     apt-get autoremove -y && \
     apt-get clean -y
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 # These can be overidden with env vars.
 REGISTRY ?= rofrano
 IMAGE_NAME ?= nyu-devops-base
-IMAGE_TAG ?= fa23
+IMAGE_TAG ?= sp24
 IMAGE ?= $(REGISTRY)/$(IMAGE_NAME):$(IMAGE_TAG)
 PLATFORM ?= "linux/amd64,linux/arm64"
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ For more information see the article [Developing inside a Container](https://cod
 
 ## Image contents
 
-This image contains the following packages on top of python:3.11-slim: `sudo`, `vim`, `make`, `git`, `zip`, `tree`, `curl`, `wget`, `jq`, `procps`, `net-tools`, `gcc`, `libpq-dev`
+This image contains the following packages on top of python:3.11-slim: `sudo`, `vim`, `make`, `git`, `zip`, `tree`, `curl`, `wget`, `jq`, `procps`, `net-tools`
 
 It also defines the user `vscode` which is needed for VSCode `features` to work properly. The `vscode` user has password-less `sudo` privileges. This teaches developers to not develop as `root` even when in a containerized environment.
 
@@ -17,7 +17,7 @@ You can use this image with this starter `devcontainer.json` file:
 ```json
 {
 	"name": "NYU DevOps",
-	"image": "rofrano/nyu-devops-base:fa23"
+	"image": "rofrano/nyu-devops-base:latest"
 }
 ```
 
@@ -28,7 +28,7 @@ Feel free to add VSCode extensions that you want every developer to have:
 ```json
 {
 	"name": "NYU DevOps",
-	"image": "rofrano/nyu-devops-base:fa23",
+	"image": "rofrano/nyu-devops-base:latest",
 	"customizations": {
 		"vscode": {
 			"extensions": [
@@ -63,7 +63,7 @@ export REGISTRY='my-account'
 make build
 ```
 
-That will tag the Docker image as `my-account/nyu-devops-base/sp3` and push it to Docker hub.
+That will tag the Docker image as `my-account/nyu-devops-base:latest` and push it to Docker hub.
 
 ## License
 


### PR DESCRIPTION
Made the following changes for Spring 2024 semester:

- Pulled the latest python:3.11-slim image
- Incremented the tag to `sp24` for Spring 2024 in the `Makefile`
- Removed `gcc` and PostgreSQL dev libs from `Dockerfile` (using binary driver now)
- Added GitHub Action to publish to both `docker.io` and `quay.io`
- Updated the README.md accordingly.

**Note:** _Docker hubs getting annoying with their anemic pull limits that fail with large cloud providers like Red Hat OpenShift, so as of this semester, I am moving many images to my [quay.io](https://quay.io/user/rofrano/) account which has no such limits._