### PR TITLE
Config poetry to not use virtual environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,8 @@ RUN groupadd --gid $USER_GID $USERNAME && \
 
 # Set up the Python development environment
 WORKDIR /app
-RUN python -m pip install --upgrade pip wheel poetry
+RUN python -m pip install --upgrade pip wheel poetry && \
+    poetry config virtualenvs.create false
 
 ENV PORT 8080
 EXPOSE $PORT


### PR DESCRIPTION
Forgot to configure poetry to not use a virtual environment since we are running in a container, the container is our virtual environment. No need for two. 