### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.11-slim
 
 # Add any tools that are needed beyond Python 3.11
 RUN apt-get update && \
-    apt-get install -y sudo vim make git zip tree curl wget jq procps net-tools iputils-ping && \
+    apt-get install -y sudo vim git build-essential zip tree curl wget jq procps net-tools iputils-ping && \
     apt-get autoremove -y && \
     apt-get clean -y
 


### PR DESCRIPTION
Added `build-essential` for Python packages that require `gcc` to compile locally.